### PR TITLE
Fix static analysis warning in generated files

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+            - non_constant_identifier_names

--- a/lib/src/generated/client.dart
+++ b/lib/src/generated/client.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 
 import 'dart:io' as io;
 import 'dart:convert';

--- a/lib/src/generated/schema/collection.dart
+++ b/lib/src/generated/schema/collection.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/collection_status.dart
+++ b/lib/src/generated/schema/collection_status.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/configure_index_request.dart
+++ b/lib/src/generated/schema/configure_index_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/create_collection_request.dart
+++ b/lib/src/generated/schema/create_collection_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/create_index_request.dart
+++ b/lib/src/generated/schema/create_index_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/delete_request.dart
+++ b/lib/src/generated/schema/delete_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/fetch_response.dart
+++ b/lib/src/generated/schema/fetch_response.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/index.dart
+++ b/lib/src/generated/schema/index.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/index_database.dart
+++ b/lib/src/generated/schema/index_database.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/index_state.dart
+++ b/lib/src/generated/schema/index_state.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/index_stats.dart
+++ b/lib/src/generated/schema/index_stats.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/index_stats_request.dart
+++ b/lib/src/generated/schema/index_stats_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/index_status.dart
+++ b/lib/src/generated/schema/index_status.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/namespace_stats.dart
+++ b/lib/src/generated/schema/namespace_stats.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/pod_type.dart
+++ b/lib/src/generated/schema/pod_type.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/query_request.dart
+++ b/lib/src/generated/schema/query_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/query_response.dart
+++ b/lib/src/generated/schema/query_response.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/schema.dart
+++ b/lib/src/generated/schema/schema.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 
 library pinecone_schema;
 

--- a/lib/src/generated/schema/schema.g.dart
+++ b/lib/src/generated/schema/schema.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: non_constant_identifier_names
+
 part of 'schema.dart';
 
 // **************************************************************************

--- a/lib/src/generated/schema/search_metric.dart
+++ b/lib/src/generated/schema/search_metric.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/sparse_vector.dart
+++ b/lib/src/generated/schema/sparse_vector.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/update_request.dart
+++ b/lib/src/generated/schema/update_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/upsert_request.dart
+++ b/lib/src/generated/schema/upsert_request.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/upsert_response.dart
+++ b/lib/src/generated/schema/upsert_response.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/vector.dart
+++ b/lib/src/generated/schema/vector.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================

--- a/lib/src/generated/schema/vector_match.dart
+++ b/lib/src/generated/schema/vector_match.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: invalid_annotation_target
 part of pinecone_schema;
 
 // ==========================================


### PR DESCRIPTION
This PR resolves the warnings from [pub.dev static analysis](https://pub.dev/packages/pinecone/score).

Some of them were caused by https://github.com/tazatechnology/openapi_spec/pull/12 (I've fixed them manually for the sake of the PR, but we need to run the generator once the new version of openapi_spec is released before merging this PR).

Others were caused by the generated files from json_serializable:
<img width="1091" alt="image" src="https://github.com/tazatechnology/pinecone/assets/6546265/4ae28a2e-da4a-4b74-98c0-96f4b2461511">

cc @walsha2 

